### PR TITLE
Remove coma after last property in oic.sec.cred

### DIFF
--- a/json-schemas/oic.sec.cred.json
+++ b/json-schemas/oic.sec.cred.json
@@ -31,7 +31,7 @@
         },
         "credusage": {
           "type": "string",
-          "description": "A string that provides hints about how/where the cred is used",
+          "description": "A string that provides hints about how/where the cred is used"
         },
         "publicdata":   {
           "type": "object",


### PR DESCRIPTION
Currently oic.sec.cred.json is not a valid json because of additional coma in line 34