### PR TITLE
Update oic.sec.dpmtype.json

### DIFF
--- a/json-schemas/oic.sec.dpmtype.json
+++ b/json-schemas/oic.sec.dpmtype.json
@@ -8,7 +8,7 @@
       "properties" : {
         "bitmask": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "maximum": 63,
           "description": "The value can be either 8 or 16 character in length. If its only 8 characters it represents the lower byte value",
           "detail-desc": [  "1 - Manufacturer reset state",


### PR DESCRIPTION
min value should be 0, not 1, as it is a bitmask and none of the states is necessarily "on" (in fact in normal operation they'll all be zero).