### PR TITLE
Add readOnly property where appropriate in the json schema's.

### DIFF
--- a/json-schemas/oic.core.json
+++ b/json-schemas/oic.core.json
@@ -17,10 +17,12 @@
             }
           ],
           "minItems" : 1,
+          "readOnly": true,
           "description": "ReadOnly, Resource Type"
         },
         "if": {
           "type" : "array",
+          "readOnly": true,
           "description": "ReadOnly, The interface set supported by this resource",
           "items": {
             "type": "string",
@@ -29,10 +31,12 @@
         },
         "n": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Friendly name of the resource"
         },
         "id": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Instance ID of this specific resource"
         }
       }

--- a/json-schemas/oic.oic-link-schema.json
+++ b/json-schemas/oic.oic-link-schema.json
@@ -27,6 +27,7 @@
             }
           ],
           "minItems" : 1,
+          "readOnly": true,
           "description": "ReadOnly, Resource Type"
         },
         "if": {
@@ -38,9 +39,11 @@
             }
           ],
           "minItems": 1,
+          "readOnly": true,
           "description": "ReadOnly, The interface set supported by this resource"
         },
         "p": {
+          "readOnly": true,
           "description": "ReadOnly, JSON object containing a Bitmap indicating observable and discoverable plus security and port",
           "type": "object",
           "properties": {

--- a/json-schemas/oic.r.doxm.json
+++ b/json-schemas/oic.r.doxm.json
@@ -8,6 +8,7 @@
       "properties": {
         "oxms":  {
           "type": "array",
+          "readOnly": true,
           "description": "ReadOnly, List of supported owner transfer methods",
           "items": {
             "$ref": "oic.sec.doxmtype.json#/definitions/oic.sec.doxmtype/properties/oxm"
@@ -18,6 +19,7 @@
           "$ref": "oic.sec.doxmtype.json#/definitions/oic.sec.doxmtype/properties/oxm"
         },
         "sct": {
+          "readOnly": true,
           "description": "ReadOnly, Bitmask encoding of supported credential types",
           "$ref": "oic.sec.credtype.json#/definitions/oic.sec.credtype/properties/bitmask"
         },
@@ -26,6 +28,7 @@
           "description": "Ownership status flag"
         },
         "deviceuuid": {
+          "readOnly": true,
           "description": "ReadOnly, The uuid formatted identity of the device",
           "type": "string",
           "format": "uuid"

--- a/json-schemas/oic.r.pstat.json
+++ b/json-schemas/oic.r.pstat.json
@@ -28,25 +28,30 @@
           "$ref": "oic.sec.pomtype.json#/definitions/oic.sec.pomtype/properties/bitmask"
         },
         "sm": {
+          "readOnly": true,
           "description": "ReadOnly, Supported operational modes",
           "$ref": "oic.sec.pomtype.json#/definitions/oic.sec.pomtype/properties/bitmask"
         },
         "deviceuuid": {
+          "readOnly": true,
           "description": "ReadOnly, Identity of the device",
           "type": "string",
           "format": "uuid"
         },
         "deviceid":   {
           "type": "object",
+          "readOnly": true,
           "description": "ReadOnly, The device to which the status applies. NULL refers to this device.",
           "$ref": "oic.sec.didtype.json"
         },
         "rowneruuid": {
+          "readOnly": true,
           "description": "ReadOnly, The UUID formatted identity of the Resource owner",
           "type": "string",
           "format": "uuid"
         },
         "rowner": {
+          "readOnly": true,
           "description": "ReadOnly, The Resource Owner in terms of either a service or host",
           "anyOf": [
             {


### PR DESCRIPTION
This change is to make the readOnly properties machine readable in
compliance with the JSON-hyper schema readOnly definition. See:
http://json-schema.org/latest/json-schema-hypermedia.html#anchor15