### PR TITLE
JSON Schema validation v4 spec doesn't recognize format=uuid.

### DIFF
--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -82,8 +82,7 @@
               "description": "Any unique string including a URI"
             },
             {
-              "type": "string",
-              "format": "uuid",
+              "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid",
               "description": "Use UUID for universal uniqueness - used in /oic/res to identify the device"
             }
           ],

--- a/schemas/oic.r.acl.json
+++ b/schemas/oic.r.acl.json
@@ -12,8 +12,7 @@
           "$ref": "oic.sec.ace.json"
         },
         "rowneruuid": {
-          "type": "string",
-          "format": "uuid",
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid",
           "description": "The value identifies the unique resource owner"
         },
         "rowner": {

--- a/schemas/oic.r.amacl.json
+++ b/schemas/oic.r.amacl.json
@@ -12,8 +12,7 @@
           "items": { "$ref": "oic.oic-link.json" }
         },
         "amsuuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "ams":   {
           "type": "object",
@@ -21,8 +20,7 @@
           "$ref": "oic.sec.svctype.json"
         },
         "rowneruuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "rowner":   {
           "type": "object",

--- a/schemas/oic.r.cred.json
+++ b/schemas/oic.r.cred.json
@@ -14,8 +14,7 @@
           }
         },
         "rowneruuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "rowner": {
           "type": "object",

--- a/schemas/oic.r.doxm.json
+++ b/schemas/oic.r.doxm.json
@@ -30,8 +30,7 @@
         "deviceuuid": {
           "readOnly": true,
           "description": "ReadOnly, The uuid formatted identity of the device",
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "deviceid":   {
           "type": "object",
@@ -39,8 +38,7 @@
           "$ref": "oic.sec.didtype.json"
         },
         "devowneruuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "devowner":   {
           "anyOf": [
@@ -56,8 +54,7 @@
           ]
         },
         "rowneruuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "rowner": {
           "anyOf": [

--- a/schemas/oic.r.pstat.json
+++ b/schemas/oic.r.pstat.json
@@ -35,8 +35,7 @@
         "deviceuuid": {
           "readOnly": true,
           "description": "ReadOnly, Identity of the device",
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "deviceid":   {
           "type": "object",
@@ -47,8 +46,7 @@
         "rowneruuid": {
           "readOnly": true,
           "description": "ReadOnly, The UUID formatted identity of the Resource owner",
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "rowner": {
           "readOnly": true,

--- a/schemas/oic.r.sacl.json
+++ b/schemas/oic.r.sacl.json
@@ -17,8 +17,7 @@
           "$ref": "oic.sec.sigtype.json"
         },
         "amsuuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "ams":   {
           "type": "object",

--- a/schemas/oic.sec.ace.json
+++ b/schemas/oic.sec.ace.json
@@ -49,9 +49,8 @@
         {
           "properties": {
             "subjectuuid": {
-              "type": "string",
-              "format": "uuid",
-              "description": "The id of the device to which the ace applies to"
+              "description": "The id of the device to which the ace applies to",
+              "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
             }
           },
           "required": [ "subjectuuid" ]

--- a/schemas/oic.sec.cred.json
+++ b/schemas/oic.sec.cred.json
@@ -11,8 +11,7 @@
           "description": "Local reference to a credential resource"
         },
         "subjectuuid": {
-          "type": "string",
-          "format": "uuid"
+          "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "subject": {
           "type": "object",

--- a/schemas/oic.sec.didtype.json
+++ b/schemas/oic.sec.didtype.json
@@ -15,9 +15,8 @@
         "id": {
           "oneOf": [
             {
-              "type": "string",
-              "format": "uuid",
-              "description": "A UUID value"
+              "description": "A UUID value",
+              "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
             }
           ]
         }


### PR DESCRIPTION
The format=uuid doesn't validate in  ATOM with apiworkbench plugin from RAML.
In the core we replaced those occurrences with an OIC defined thype using string and pattern.   
See https://github.com/stephanesan/core/blob/master/schemas/oic.types-schema.json
The proposal here is to replace those failing "format=uuid" occurrences with the uuid type already defined in the ocf core types.
This will allow the validator to proceed past this error to validate the remaining code.