### PR TITLE
Fix svctype ref

### DIFF
--- a/schemas/oic.r.acl.json
+++ b/schemas/oic.r.acl.json
@@ -20,7 +20,7 @@
           "oneOf": [
             {
               "type": "object",
-              "$ref": "oic.sec.svctype.json",
+              "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype",
               "description": "Entries in oic.sec.svc resource that own this resource"
             },
             {

--- a/schemas/oic.r.amacl.json
+++ b/schemas/oic.r.amacl.json
@@ -18,7 +18,7 @@
         "ams":   {
           "type": "object",
           "description": "Entries in oic.sec.svc resource that manage access for the specified resource",
-          "$ref": "oic.sec.svctype.json"
+          "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
         },
         "rowneruuid": {
           "type": "string",
@@ -27,7 +27,7 @@
         "rowner":   {
           "type": "object",
           "description": "Entries in oic.sec.svc resource that own this resource",
-          "$ref": "oic.sec.svctype.json"
+          "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
         }
       }
     }

--- a/schemas/oic.r.cred.json
+++ b/schemas/oic.r.cred.json
@@ -20,7 +20,7 @@
         "rowner": {
           "type": "object",
           "description": "Entries in /oic/sec/svc resource that own this resource",
-          "$ref": "oic.sec.svctype.json"
+          "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
         }
       }
     }

--- a/schemas/oic.r.doxm.json
+++ b/schemas/oic.r.doxm.json
@@ -47,7 +47,7 @@
             {
               "type": "object",
               "description": "Entries in oic.sec.svc resource that own this resource",
-              "$ref": "oic.sec.svctype.json"
+              "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
             },
             {
               "type": "object",
@@ -64,7 +64,7 @@
             {
               "type": "object",
               "description": "Entries in oic.sec.svc resource that own this resource",
-              "$ref": "oic.sec.svctype.json"
+              "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
             },
             {
               "type": "object",

--- a/schemas/oic.r.pstat.json
+++ b/schemas/oic.r.pstat.json
@@ -57,7 +57,7 @@
             {
               "type": "object",
               "description": "Entries in /oic/sec/svc resource that own this resource",
-              "$ref": "oic.sec.svctype.json"
+              "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
             },
             {
               "type": "object",

--- a/schemas/oic.r.sacl.json
+++ b/schemas/oic.r.sacl.json
@@ -23,7 +23,7 @@
         "ams":   {
           "type": "object",
           "description": "Entries in oic.sec.svc resource that manage access for the specified resource",
-          "$ref": "oic.sec.svctype.json"
+          "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
         }
       }
     }

--- a/schemas/oic.r.svc.json
+++ b/schemas/oic.r.svc.json
@@ -16,7 +16,7 @@
         "rowner":   {
           "type": "object",
           "description": "Entries in oic.sec.svc resource that own this resource",
-          "$ref": "oic.sec.svctype.json"
+          "$ref": "oic.sec.svctype.json#/definitions/oic.sec.svctype"
         }
       }
     }

--- a/schemas/oic.sec.svctype.json
+++ b/schemas/oic.sec.svctype.json
@@ -20,12 +20,12 @@
                               "all - matches all service types" ]
           }
         }
-      }
+      },
+      "required": [ "sl" ]
     }
   },
   "type": "object",
   "allOf": [
     { "$ref": "#/definitions/oic.sec.svctype" }
-  ],
-  "required": [ "sl" ]
+  ]
 }


### PR DESCRIPTION
Using references to definitions works properly in ATOM and gets rid of the useless allOf anyway. 
In short, this hack solves the ATOM api-workbench limitation and but at the same time cleans up the schema design!
