### PR TITLE
Fix acl ref

### DIFF
--- a/schemas/oic.r.acl.json
+++ b/schemas/oic.r.acl.json
@@ -9,7 +9,7 @@
         "aclist":  {
           "type": "object",
           "description": "Access Control Entries in the Acl resource",
-          "$ref": "oic.sec.ace.json"
+          "$ref": "oic.sec.ace.json#/definitions/oic.sec.ace"
         },
         "rowneruuid": {
           "type": "string",

--- a/schemas/oic.r.sacl.json
+++ b/schemas/oic.r.sacl.json
@@ -9,7 +9,7 @@
         "aclist":  {
           "type": "object",
           "description": "Access Control Entries in the Acl resource",
-          "$ref": "oic.sec.ace.json"
+          "$ref": "oic.sec.ace.json#/definitions/oic.sec.ace"
         },
         "signature":   {
           "type": "object",

--- a/schemas/oic.sec.ace.json
+++ b/schemas/oic.sec.ace.json
@@ -43,7 +43,7 @@
       },
       "required": [ "resources", "permission" ]
     },
-    "oic.sec.ace": {
+    "oic.sec.ace1": {
       "allOf": [
         { "$ref": "#/definitions/oic.sec.acebase" },
         {
@@ -67,10 +67,10 @@
               "description": "The subject to whom this ace applies, either a deviceId or a role",
               "anyOf": [
                 {
-                  "$ref": "oic.sec.didtype.json"
+                  "$ref": "oic.sec.didtype.json#/definitions/oic.sec.didtype"
                 },
                 {
-                  "$ref": "oic.sec.roletype.json"
+                  "$ref": "oic.sec.roletype.json#/definitions/oic.sec.roletype"
                 }
               ]
             }
@@ -78,20 +78,24 @@
           "required": [ "subject" ]
         }
       ]
-    }
-  },
-  "type": "object",
-  "properties": {
-    "aces": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/oic.sec.ace"
-      }
     },
-    "aces2": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/oic.sec.ace2"
+    "oic.sec.ace" : {
+      "type": "object",
+      "properties": {
+        "aces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/oic.sec.ace1"
+          }
+        },
+        "aces2": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/oic.sec.ace2"
+          }
+        }
       }
     }
   }

--- a/schemas/oic.sec.cred.json
+++ b/schemas/oic.sec.cred.json
@@ -22,7 +22,7 @@
         "roleid": {
           "type": "object",
           "description": "The roles this credential possesses",
-          "$ref": "oic.sec.roletype.json"
+          "$ref": "oic.sec.roletype.json#/definitions/oic.sec.roletype"
         },
         "credtype": {
           "type": "integer",

--- a/schemas/oic.sec.roletype.json
+++ b/schemas/oic.sec.roletype.json
@@ -5,25 +5,26 @@
   "definitions": {
     "oic.sec.roletype": {
       "type": "object",
-      "description": "Security roles specified as an <Authority> & <Rolename>. A NULL <Authority> refers to the local entity or device.",
       "properties": {
-        "authority": {
-          "type": "string",
-          "description": "The Authority component of the entity being identified"
-        },
-        "roles": {
-          "type": "array",
-          "description": "Each value specifies some well known role",
-          "items": {
-            "type": "string"
+        "rl": {
+          "type": "object",
+          "description": "Security roles specified as an <Authority> & <Rolename>. A NULL <Authority> refers to the local entity or device.",
+          "properties": {
+            "authority": {
+              "type": "string",
+              "description": "The Authority component of the entity being identified"
+            },
+            "roles": {
+              "type": "array",
+              "description": "Each value specifies some well known role",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         }
-      }
+      },
+      "required": [ "rl" ]
     }
-  },
-  "type": "object",
-  "properties": {
-    "rl": { "$ref": "#/definitions/oic.sec.roletype" }
-  },
-  "required": [ "rl" ]
+  }
 }


### PR DESCRIPTION
Using references to definitions works properly in ATOM and gets rid of the useless allOf anyway.
In short, this hack solves the ATOM api-workbench limitation and but at the same time cleans up the schema design!