### PR TITLE
Fix example in acl.raml.

### DIFF
--- a/oic.r.acl.raml
+++ b/oic.r.acl.raml
@@ -47,8 +47,14 @@ traits:
                       ],
                       "permission": 31,
                       "validity": [
-                        [ "20160101T180000Z/20170102T070000Z", [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ] ],
-                        [ "20160101T180000Z/PT5H30M", [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ] ]
+                        {
+                          "period":"20160101T180000Z/20170102T070000Z",
+                          "recurrence": [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
+                        },
+                        {
+                          "period":"20160101T180000Z/PT5H30M",
+                          "recurrence": [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
+                        }
                       ]
                     },
                   ],
@@ -104,7 +110,7 @@ traits:
                 "rowneruuid": "de305d54-75b4-431b-adb2-eb6b9e546014",
                 "rowner": {
                   "hostid": {
-                    "idt": 0,
+                    "idt": "0",
                     "id": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
                   }
                 }
@@ -140,8 +146,14 @@ traits:
                   ],
                   "permission": 31,
                   "validity": [
-                    [ "20160101T180000Z/20170102T070000Z", [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ] ],
-                    [ "20160101T180000Z/PT5H30M", [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ] ]
+                    {
+                      "period":"20160101T180000Z/20170102T070000Z",
+                      "recurrence": [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
+                    },
+                    {
+                      "period":"20160101T180000Z/PT5H30M",
+                      "recurrence": [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
+                    }
                   ]
                 },
               ],
@@ -197,6 +209,7 @@ traits:
             "rowneruuid": "de305d54-75b4-431b-adb2-eb6b9e546014",
             "rowner": {
               "hostid": {
+                "idt": "0",
                 "id": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
               }
             }
@@ -238,8 +251,14 @@ traits:
                   ],
                   "permission": 31,
                   "validity": [
-                    [ "20160101T180000Z/20170102T070000Z", [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ] ],
-                    [ "20160101T180000Z/PT5H30M", [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ] ]
+                    {
+                      "period":"20160101T180000Z/20170102T070000Z",
+                      "recurrence": [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
+                    },
+                    {
+                      "period":"20160101T180000Z/PT5H30M",
+                      "recurrence": [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
+                    }
                   ]
                 },
               ],
@@ -295,6 +314,7 @@ traits:
             "rowneruuid": "de305d54-75b4-431b-adb2-eb6b9e546014",
             "rowner": {
               "hostid": {
+                "idt": "0",
                 "id": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
               }
             }


### PR DESCRIPTION
Fix example to match the time-interval schema definition.
Add missing idt property.