### PR TITLE
Fix the schema to fit the example in svc.raml.

### DIFF
--- a/schemas/oic.sec.svc.json
+++ b/schemas/oic.sec.svc.json
@@ -17,9 +17,8 @@
           "$ref": "oic.sec.svctype.json"
         },
         "sct": {
-          "type": "object",
           "description": "Bitmask of supported credential types",
-          "$ref": "oic.sec.credtype.json"
+          "$ref": "oic.sec.credtype.json#/definitions/oic.sec.credtype/properties/bitmask"
         },
         "scid": {
           "type": "integer",


### PR DESCRIPTION
The pattern in the other files seem to indicate that the bitmask
property is never directly included but rather used as a type
definition reference. So the schema is modified to comply with this
design pattern.