### PR TITLE
Removed "ReadOnly" from description fields for ReadOnly properties

### DIFF
--- a/schemas/oic.r.doxm.json
+++ b/schemas/oic.r.doxm.json
@@ -9,7 +9,7 @@
         "oxms":  {
           "type": "array",
           "readOnly": true,
-          "description": "ReadOnly, List of supported owner transfer methods",
+          "description": "List of supported owner transfer methods",
           "items": {
             "$ref": "oic.sec.doxmtype.json#/definitions/oic.sec.doxmtype/properties/oxm"
           }
@@ -20,7 +20,7 @@
         },
         "sct": {
           "readOnly": true,
-          "description": "ReadOnly, Bitmask encoding of supported credential types",
+          "description": "Bitmask encoding of supported credential types",
           "$ref": "oic.sec.credtype.json#/definitions/oic.sec.credtype/properties/bitmask"
         },
         "owned":   {
@@ -29,7 +29,7 @@
         },
         "deviceuuid": {
           "readOnly": true,
-          "description": "ReadOnly, The uuid formatted identity of the device",
+          "description": "The uuid formatted identity of the device",
           "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "deviceid":   {

--- a/schemas/oic.r.pstat.json
+++ b/schemas/oic.r.pstat.json
@@ -29,28 +29,28 @@
         },
         "sm": {
           "readOnly": true,
-          "description": "ReadOnly, Supported operational modes",
+          "description": "Supported operational modes",
           "$ref": "oic.sec.pomtype.json#/definitions/oic.sec.pomtype/properties/bitmask"
         },
         "deviceuuid": {
           "readOnly": true,
-          "description": "ReadOnly, Identity of the device",
+          "description": "Identity of the device",
           "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "deviceid":   {
           "type": "object",
           "readOnly": true,
-          "description": "ReadOnly, The device to which the status applies. NULL refers to this device.",
+          "description": "The device to which the status applies. NULL refers to this device.",
           "$ref": "oic.sec.didtype.json#/definitions/oic.sec.didtype"
         },
         "rowneruuid": {
           "readOnly": true,
-          "description": "ReadOnly, The UUID formatted identity of the Resource owner",
+          "description": "The UUID formatted identity of the Resource owner",
           "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "rowner": {
           "readOnly": true,
-          "description": "ReadOnly, The Resource Owner in terms of either a service or host",
+          "description": "The Resource Owner in terms of either a service or host",
           "anyOf": [
             {
               "type": "object",


### PR DESCRIPTION
Since the property tag has been introduced, the ReadOnly string in the description is no longer necessary.