### PR TITLE
Schema changes for spec change request CR-37 (ResourceTableUpdates))

### DIFF
--- a/schemas/oic.r.pstat.json
+++ b/schemas/oic.r.pstat.json
@@ -39,17 +39,14 @@
         },
         "deviceid":   {
           "type": "object",
-          "readOnly": true,
           "description": "The device to which the status applies. NULL refers to this device.",
           "$ref": "oic.sec.didtype.json#/definitions/oic.sec.didtype"
         },
         "rowneruuid": {
-          "readOnly": true,
           "description": "The UUID formatted identity of the Resource owner",
           "$ref": "../../core/schemas/oic.types-schema.json#/definitions/uuid"
         },
         "rowner": {
-          "readOnly": true,
           "description": "The Resource Owner in terms of either a service or host",
           "anyOf": [
             {


### PR DESCRIPTION
CR Summary:

Various resource tables in the specification do not reflect the JSON schemas. This CR attempts to bring the spec in sync with the schema files.

This includes a number of changes to UUID references and definitions.
