### PR TITLE
OCF 1.0/CR-32: Off-Boarding

### DIFF
--- a/schemas/oic.sec.dostype.json
+++ b/schemas/oic.sec.dostype.json
@@ -9,12 +9,13 @@
         "s": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 3,
-          "description": "The value can be either 0, 1, 2 or 3",
+          "maximum": 4,
+          "description": "The current or pending operational state",
           "detail-desc": [  "0 - RESET - Device reset state",
                             "1 - RFOTM - Ready for device owner transfer method state",
                             "2 - RFPRO - Ready for device provisioning state",
-                            "3 - RFNOP - Ready for device normal operation state" ]
+                            "3 - RFNOP - Ready for device normal operation state",
+                            "4 - SRESET - The device is in a soft reset state" ]
         },
         "p": {
           "type": "boolean",


### PR DESCRIPTION
BridgingTG requires a method for removing a device from operation and for preparing the device for use by a different network. It is also desirable to temporarily disable the device without removing it from the network / domain. This is described as “off-boarding”.