### PR TITLE
OCF 1.0/CR-34: ACE Matching 

### DIFF
--- a/schemas/oic.sec.ace2.json
+++ b/schemas/oic.sec.ace2.json
@@ -18,6 +18,15 @@
             },
             "if": {
               "$ref": "oic.oic-link-schema.json#/properties/if"
+            },
+            "rule": {
+              "type": "string",
+              "enum": [ "+", "-", "*" ],
+              "description": "A wildcard matching policy",
+              "detail-desc": [  "+ - Matches all discoverable resources",
+                                "- - Matches all non-discoverable resources",
+                                "* - Matches all resources"
+              ]
             }
           }
         },

--- a/schemas/oic.sec.ace2.json
+++ b/schemas/oic.sec.ace2.json
@@ -9,7 +9,17 @@
         "resources": {
           "type": "array",
           "description": "References the application's resources to which a security policy applies",
-          "items": { "$ref": "../../core/schemas/oic.oic-link-schema.json#/definitions/oic.oic-link" }
+          "items": {
+            "href": {
+              "$ref": "oic.oic-link-schema.json#/properties/href"
+            },
+            "rt": {
+              "$ref": "oic.oic-link-schema.json#/properties/rt"
+            },
+            "if": {
+              "$ref": "oic.oic-link-schema.json#/properties/if"
+            }
+          }
         },
         "permission": {
           "type": "integer",
@@ -38,7 +48,7 @@
           }
         }
       },
-      "required": [ "resources", "permission", "subject" ]
+      "required": [ "permission", "subject" ]
     }
   }
 }

--- a/schemas/oic.sec.ace2.json
+++ b/schemas/oic.sec.ace2.json
@@ -10,16 +10,20 @@
           "type": "array",
           "description": "References the application's resources to which a security policy applies",
           "items": {
+            "description": "Each resource must have at least one of these properties set",
             "href": {
+              "description": "When present, the ACE only applies when the href matches",
               "$ref": "oic.oic-link-schema.json#/properties/href"
             },
             "rt": {
+              "description": "When present, the ACE only applies when the rt (resource type) matches",
               "$ref": "oic.oic-link-schema.json#/properties/rt"
             },
             "if": {
+              "description": "When present, the ACE only applies when the if (interface) matches",
               "$ref": "oic.oic-link-schema.json#/properties/if"
             },
-            "rule": {
+            "wc": {
               "type": "string",
               "enum": [ "+", "-", "*" ],
               "description": "A wildcard matching policy",


### PR DESCRIPTION
Description from the CR:

OIC v1.1 specification is unclear regarding the use of wildcard matching of resources in and ACE and the order of evaluation when matching resources.