### PR TITLE
Fixed names for the various doxmtypes to start with "oic.sec.doxm" in…

### DIFF
--- a/schemas/oic.sec.doxmtype.json
+++ b/schemas/oic.sec.doxmtype.json
@@ -10,10 +10,10 @@
         "oxm": {
           "type": "integer",
           "description": "Each value indicates a specific Owner Transfer method",
-          "detail-desc": [  "0 - Numeric OTM identifier for the Just-Works method (oic.sec.oxm.jw)",
-                            "1 - Numeric OTM identifier for the random PIN method (oic.sec.oxm.rdp)",
-                            "2 - Numeric OTM identifier for the manufacturer certificate method (oic.sec.oxm.mfgcert)",
-                            "3 - Numeric OTM identifier for the decap method (oic.sec.oxm.dcap) (deprecated)" ]
+          "detail-desc": [  "0 - Numeric OTM identifier for the Just-Works method (oic.sec.doxm.jw)",
+                            "1 - Numeric OTM identifier for the random PIN method (oic.sec.doxm.rdp)",
+                            "2 - Numeric OTM identifier for the manufacturer certificate method (oic.sec.doxm.mfgcert)",
+                            "3 - Numeric OTM identifier for the decap method (oic.sec.doxm.dcap) (deprecated)" ]
         }
       }
     }


### PR DESCRIPTION
Fixed names for the various doxmtypes to start with "oic.sec.doxm" instead of "oic.sec.oxm"

From the CR description:

Doxmtype URN used in Section 7.3 (oic.sec.doxm.xxx) and Section 13.1.1 (oic.sec.oxm.xxx) are inconsistent. Section 13.1.1 Table is corrected to align with Ownership Transfer Flows in Section 7.3.

https://workspace.openconnectivity.org/apps/org/workgroup/security_wg/document.php?document_id=7757