### PR TITLE
CR 1502: Query Parameter Clarifications

### DIFF
--- a/oic.r.acl.raml
+++ b/oic.r.acl.raml
@@ -19,7 +19,10 @@ traits:
 
   get:
     description: |
-      Retrieves the acl data.
+      Retrieves the ACL data.
+      When used without query parameters, all the ACE entries are returned.
+      When used with a subjectuuid or resources query parameter, only the
+      ACEs matching the specified parameter are returned.
     queryParameters:
         subjectuuid:
             type: string
@@ -27,16 +30,14 @@ traits:
               Returns ACEs with the specificed subject UUID
             required: false
             repeat: false
-            example: |
-                GET /myacl?subject="e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
+            example: se61c3e6b-9c54-4b81-8ce5-f9039c1d04d9
         resources:
             type: string
             description: |
               Returns ACEs with the specificed resource href
             required: false
             repeat: false
-            example: |
-                GET /myacl?resources="coaps://IP-ADDR/temp"
+            example: coaps://IP-ADDR/temp
     responses:
       200:
         body:
@@ -137,8 +138,9 @@ traits:
   delete:
     description: |
       Deletes ACL entries.
-      When DELETE is used without query parameters, all the acl entries are deleted.
-      When DELETE is used with a subjectuuid query parameter, only the entries matching the subjectuuid are deleted.
+      When DELETE is used without query parameters, all the ACE entries are deleted.
+      When DELETE is used with a subjectuuid or resources query parameter, only the
+      ACEs matching the specified parameter are deleted.
     queryParameters:
         subjectuuid:
             type: string
@@ -146,16 +148,14 @@ traits:
               Deletes the ACL(s) identified by the string containing subjectuuid.
               e.g. DELETE /myacl?subjectuuid="de305d54-75b4-431b-adb2-eb6b9e546014"
             required: false
-            example: |
-                DELETE /myacl?subjectuuid="de305d54-75b4-431b-adb2-eb6b9e546014"
+            example: de305d54-75b4-431b-adb2-eb6b9e546014
         resources:
             type: string
             description: |
-              Returns ACEs with the specificed resource href
+              Deletes ACEs with the specificed resource href
             required: false
             repeat: false
-            example: |
-                GET /myacl?resources="coaps://IP-ADDR/temp"
+            example: coaps://IP-ADDR/temp
 
     responses:
       200:

--- a/oic.r.acl.raml
+++ b/oic.r.acl.raml
@@ -9,6 +9,23 @@ traits:
       queryParameters:
         if:
           enum: ["oic.if.baseline"]
+  - ace-filtered:
+      usage: Apply this to any method that can filter ACEs
+      description: Some requests only operate on a subset of ACEs
+      queryParameters:
+        subjectuuid:
+            type: string
+            description: Only applies to ACEs with the specified subject UUID
+            required: false
+            repeat: false
+            example: se61c3e6b-9c54-4b81-8ce5-f9039c1d04d9
+        resources:
+            type: string
+            description: Only applies to ACEs with the specificed subhectuuid |
+                         and resources href
+            required: false
+            repeat: false
+            example: coaps://IP-ADDR/temp
 
 /SecAclResURI:
   description: |
@@ -19,25 +36,14 @@ traits:
 
   get:
     description: |
-      Retrieves the ACL data.
+      Retrieves the ACL entries.
+
       When used without query parameters, all the ACE entries are returned.
-      When used with a subjectuuid or resources query parameter, only the
-      ACEs matching the specified parameter are returned.
-    queryParameters:
-        subjectuuid:
-            type: string
-            description: |
-              Returns ACEs with the specificed subject UUID
-            required: false
-            repeat: false
-            example: se61c3e6b-9c54-4b81-8ce5-f9039c1d04d9
-        resources:
-            type: string
-            description: |
-              Returns ACEs with the specificed resource href
-            required: false
-            repeat: false
-            example: coaps://IP-ADDR/temp
+      When used with a subjectuuid, only the ACEs with the specified
+      subjectuuid are returned. If subjectuuid and resources are specified,
+      only the ACEs with the specified subjectuuid and resource hrefs are
+      returned.
+    is: [ace-filtered]
     responses:
       200:
         body:
@@ -138,27 +144,15 @@ traits:
   delete:
     description: |
       Deletes ACL entries.
-      When DELETE is used without query parameters, all the ACE entries are deleted.
-      When DELETE is used with a subjectuuid or resources query parameter, only the
-      ACEs matching the specified parameter are deleted.
-    queryParameters:
-        subjectuuid:
-            type: string
-            description: |
-              Deletes the ACL(s) identified by the string containing subjectuuid.
-              e.g. DELETE /myacl?subjectuuid="de305d54-75b4-431b-adb2-eb6b9e546014"
-            required: false
-            example: de305d54-75b4-431b-adb2-eb6b9e546014
-        resources:
-            type: string
-            description: |
-              Deletes ACEs with the specificed resource href
-            required: false
-            repeat: false
-            example: coaps://IP-ADDR/temp
 
+      When DELETE is used without query parameters, all the ACE entries are deleted.
+      When DELETE is used with a subjectuuid, only the ACEs with the specified
+      subjectuuid are deleted. If subjectuuid and resources are specified,
+      only the ACEs with the specified subjectuuid and resource hrefs are
+      deleted.
+    is: [ace-filtered]
     responses:
       200:
-        description: The matching ACL instances or the the entire ACL resource has been successfully deleted.
+        description: The matching ACEs or the entire ACL resource has been successfully deleted.
       400:
         description: The request is invalid.

--- a/oic.r.acl.raml
+++ b/oic.r.acl.raml
@@ -93,6 +93,11 @@ traits:
       Updates the ACL resource with the provided values. ACEs provided
       in the update not currently in the ACL are added. ACEs that already
       exist in the ACL are ignored.
+
+      Note that for the purposes of update, equivalency is determined
+      by comparing the ACE subjectuuid, permission, string comparisons
+      of all validity elements, and string comparisons of all resource
+      hrefs.
     body:
       application/json:
         schema: Acl

--- a/oic.r.acl.raml
+++ b/oic.r.acl.raml
@@ -20,6 +20,23 @@ traits:
   get:
     description: |
       Retrieves the acl data.
+    queryParameters:
+        subjectuuid:
+            type: string
+            description: |
+              Returns ACEs with the specificed subject UUID
+            required: false
+            repeat: false
+            example: |
+                GET /myacl?subject="e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
+        resources:
+            type: string
+            description: |
+              Returns ACEs with the specificed resource href
+            required: false
+            repeat: false
+            example: |
+                GET /myacl?resources="coaps://IP-ADDR/temp"
     responses:
       200:
         body:
@@ -66,7 +83,9 @@ traits:
 
   post:
     description: |
-      Updates the ACL resource with the provided values.
+      Updates the ACL resource with the provided values. ACEs provided
+      in the update not currently in the ACL are added. ACEs that already
+      exist in the ACL are ignored.
     body:
       application/json:
         schema: Acl
@@ -109,58 +128,9 @@ traits:
 
     responses:
       201:
-        description: The ACL entry is created.
+        description: The ACL entry/entries is/are created.
       204:
-        description: The ACL entry is updated.
-      400:
-        description: The request is invalid.
-
-  put:
-    description: |
-      Creates the new acl data
-    body:
-      application/json:
-        schema: Acl
-        example: |
-          {
-            "aclist": {
-              "aces": [
-                {
-                  "subjectuuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9",
-                  "resources": [
-                    {
-                      "href": "coaps://IP-ADDR/temp",
-                      "rel": "some-rel",
-                      "rt": ["oic.r.temperature"],
-                      "if": ["oic.if.a"]
-                    },
-                    {
-                      "href": "coaps://IP-ADDR/temp",
-                      "rel": "some-rel",
-                      "rt": ["oic.r.temperature"],
-                      "if": ["oic.if.s"]
-                    }
-                  ],
-                  "permission": 31,
-                  "validity": [
-                    {
-                      "period":"20160101T180000Z/20170102T070000Z",
-                      "recurrence": [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
-                    },
-                    {
-                      "period":"20160101T180000Z/PT5H30M",
-                      "recurrence": [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
-                    }
-                  ]
-                }
-              ]
-            },
-            "rowneruuid": "de305d54-75b4-431b-adb2-eb6b9e546014"
-          }
-
-    responses:
-      201:
-        description: The ACL entry is created.
+        description: The ACL entry/entries is/are updated.
       400:
         description: The request is invalid.
 
@@ -178,6 +148,14 @@ traits:
             required: false
             example: |
                 DELETE /myacl?subjectuuid="de305d54-75b4-431b-adb2-eb6b9e546014"
+        resources:
+            type: string
+            description: |
+              Returns ACEs with the specificed resource href
+            required: false
+            repeat: false
+            example: |
+                GET /myacl?resources="coaps://IP-ADDR/temp"
 
     responses:
       200:

--- a/oic.r.acl2.raml
+++ b/oic.r.acl2.raml
@@ -20,6 +20,24 @@ traits:
   get:
     description: |
       Retrieves the ACL data.
+      When used without query parameters, all the ACE entries are returned.
+      When used with an aceid or resources query parameter, only the
+      ACEs matching the specified parameter are returned.
+    queryParameters:
+      aceid:
+          type: integer
+          description: |
+            Returns ACE with the specificed aceid
+          required: false
+          repeat: false
+          example: 2112
+      resources:
+          type: string
+          description: |
+            Returns ACEs with the specificed resource href
+          required: false
+          repeat: false
+          example: coaps://IP-ADDR/temp
     responses:
       200:
         body:
@@ -112,6 +130,15 @@ traits:
   post:
     description: |
       Updates the ACL resource with the provided values.
+
+      ACEs provided in the update with aceids not currently in the ACL are
+      added.
+
+      ACEs provided in the update with aceids already in the ACL replace
+      existing ACEs in correspondance with the aceids.
+
+      ACEs provided in the update without aceid entries are added and
+      assigned unique aceids.
     body:
       application/json:
         schema: Acl2
@@ -177,97 +204,28 @@ traits:
       400:
         description: The request is invalid.
 
-  put:
-    description: |
-      Creates the new ACL data
-    body:
-      application/json:
-        schema: Acl2
-        example: |
-          {
-            "aclist": [
-              {
-                "subject": {
-                  "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
-                  "roles": [
-                    "SOME_STRING", "SOME_STRING"
-                  ]
-                },
-                "resources": [
-                  {
-                    "href": "coaps://IP-ADDR/light",
-                    "rel": "some-rel",
-                    "rt": ["oic.r.light"],
-                    "if": ["oic.if.a"]
-                  },
-                  {
-                    "href": "coaps://IP-ADDR/door",
-                    "rel": "some-rel",
-                    "rt": ["oic.r.door"],
-                    "if": ["oic.if.a"]
-                  }
-                ],
-                "permission": 24,
-                "validity": [
-                  {
-                    "period":"20160101T180000Z/20170102T070000Z",
-                    "recurrence": [ "DSTART:XXXXX", "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
-                  },
-                  {
-                    "period":"20160101T180000Z/PT5H30M",
-                    "recurrence": [ "RRULE:FREQ=DAILY;UNTIL=20180131T140000Z;BYMONTH=1" ]
-                  }
-                ]
-              },
-              {
-                "subject": {
-                  "uuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
-                },
-                "resources": [
-                  {
-                    "href": "coaps://IP-ADDR/light",
-                    "rel": "some-rel",
-                    "rt": ["oic.r.light"],
-                    "if": ["oic.if.a"]
-                  },
-                  {
-                    "href": "coaps://IP-ADDR/door",
-                    "rel": "some-rel",
-                    "rt": ["oic.r.door"],
-                    "if": ["oic.if.a"]
-                  }
-                ],
-                "permission": 24
-              }
-            ],
-            "rowner": {
-              "hostid": {
-                "uuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
-              }
-            }
-          }
-
-    responses:
-      201:
-        description: The ACL entry is created.
-      400:
-        description: The request is invalid.
-
   delete:
+
     description: |
       Deletes ACL entries.
-      When DELETE is used without query parameters, all the acl entries are deleted.
-      When DELETE is used with a subjectuuid query parameter, only the entries matching the subjectuuid are deleted.
+      When DELETE is used without query parameters, all the ACE entries are deleted.
+      When DELETE is used with an aceid or resources query parameter, only the
+      ACEs matching the specified parameter are deleted.
     queryParameters:
-        subjectuuid:
-            type: string
-            description: |
-              Deletes the ACL(s) identified by the string containing subjectuuid.
-              e.g. DELETE /myacl?subjectuuid="de305d54-75b4-431b-adb2-eb6b9e546014"
-            required: false
-            example: |
-                DELETE /myacl?subjectuuid="de305d54-75b4-431b-adb2-eb6b9e546014"
-
+      aceid:
+          type: integer
+          description: |
+            Deletes the ACE with the specificed aceid
+          required: false
+          repeat: false
+          example: 2112
+      resources:
+          type: string
+          description: |
+            Deletes ACEs with the specificed resource href
+          required: false
+          repeat: false
+          example: coaps://IP-ADDR/temp
     responses:
       200:
         description: The matching ACL instances or the the entire ACL resource has been successfully deleted.

--- a/oic.r.acl2.raml
+++ b/oic.r.acl2.raml
@@ -9,6 +9,29 @@ traits:
       queryParameters:
         if:
           enum: ["oic.if.baseline"]
+  - ace-filtered:
+      usage: Apply this to any method that can filter ACEs
+      description: Some requests only operate on a subset of ACEs
+      queryParameters:
+        aceid:
+            type: integer
+            description: Only applies to the ACE with the specified aceid
+            required: false
+            repeat: false
+            example: 2112
+        subjectuuid:
+            type: string
+            description: Only applies to ACEs with the specified subject UUID
+            required: false
+            repeat: false
+            example: se61c3e6b-9c54-4b81-8ce5-f9039c1d04d9
+        resources:
+            type: string
+            description: Only applies to ACEs with the specificed subhectuuid |
+                         and resources href
+            required: false
+            repeat: false
+            example: coaps://IP-ADDR/temp
 
 /SecAclResURI:
   description: |
@@ -23,21 +46,7 @@ traits:
       When used without query parameters, all the ACE entries are returned.
       When used with an aceid or resources query parameter, only the
       ACEs matching the specified parameter are returned.
-    queryParameters:
-      aceid:
-          type: integer
-          description: |
-            Returns ACE with the specificed aceid
-          required: false
-          repeat: false
-          example: 2112
-      resources:
-          type: string
-          description: |
-            Returns ACEs with the specificed resource href
-          required: false
-          repeat: false
-          example: coaps://IP-ADDR/temp
+    is: [ace-filtered]
     responses:
       200:
         body:
@@ -47,6 +56,7 @@ traits:
               {
                 "aclist": [
                   {
+                    "aceid": 1,
                     "subject": {
                       "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
                       "roles": [
@@ -70,6 +80,7 @@ traits:
                     "permission": 24
                   },
                   {
+                    "aceid": 2,
                     "subject": {
                       "uuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
                     },
@@ -146,6 +157,7 @@ traits:
           {
             "aclist": [
               {
+                "aceid": 1,
                 "subject": {
                   "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
                   "roles": [
@@ -169,6 +181,7 @@ traits:
                 "permission": 24
               },
               {
+                "aceid": 3,
                 "subject": {
                   "uuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9"
                 },
@@ -209,25 +222,11 @@ traits:
     description: |
       Deletes ACL entries.
       When DELETE is used without query parameters, all the ACE entries are deleted.
-      When DELETE is used with an aceid or resources query parameter, only the
+      When DELETE is used with an aceid and/or resources query parameter, only the
       ACEs matching the specified parameter are deleted.
-    queryParameters:
-      aceid:
-          type: integer
-          description: |
-            Deletes the ACE with the specificed aceid
-          required: false
-          repeat: false
-          example: 2112
-      resources:
-          type: string
-          description: |
-            Deletes ACEs with the specificed resource href
-          required: false
-          repeat: false
-          example: coaps://IP-ADDR/temp
+    is: [ace-filtered]
     responses:
       200:
-        description: The matching ACL instances or the the entire ACL resource has been successfully deleted.
+        description: The matching ACEs or the entire ACL resource has been successfully deleted.
       400:
         description: The request is invalid.

--- a/schemas/oic.sec.ace2.json
+++ b/schemas/oic.sec.ace2.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://www.openconnectivity.org/ocf-apis/security/schemas/oic.sec.ace2.json#",
-  "title": "Subject based Access Control Entry (ACE) object definition",
+  "title": "Subject-based Access Control Entry (ACE) object definition",
   "definitions": {
     "oic.sec.ace2": {
       "type": "object",

--- a/schemas/oic.sec.ace2.json
+++ b/schemas/oic.sec.ace2.json
@@ -6,6 +6,13 @@
     "oic.sec.ace2": {
       "type": "object",
       "properties": {
+        "aceid": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "An identifier for the ACE that is unique within the ACL.
+                          In cases where it isn't supplied in an update, the Server
+                          will add the ACE and assign it a unique value.",
+        },
         "resources": {
           "type": "array",
           "description": "References the application's resources to which a security policy applies",


### PR DESCRIPTION
While looking into what query parameters and UPDATE semantics need to be supported for ACL2, we realized that ACL query parameters and UPDATE semantics were not properly described in the RAML. CTT and IoTivity already had assumed/defined certain ACL query parameters and UPDATE semantics. This PR attempts to reconcile and resolve these issues.