### PR TITLE
Make oic.sec.roletype consistent with spec'd definition

### DIFF
--- a/examples/oic.sec.roletype-example.json
+++ b/examples/oic.sec.roletype-example.json
@@ -1,8 +1,6 @@
 {
   "rl": {
     "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
-    "roles": [
-      "SOME_STRING", "SOME_STRING"
-    ]
+    "role": "SOME_STRING"
   }
 }

--- a/oic.r.cred.raml
+++ b/oic.r.cred.raml
@@ -55,9 +55,7 @@ traits:
                     "subjectuuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9",
                     "roleid": {
                       "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
-                      "roles": [
-                        "SOME_STRING", "SOME_STRING"
-                      ]
+                      "role": "SOME_STRING"
                     },
                     "credtype": 32,
                     "publicdata": {
@@ -82,9 +80,7 @@ traits:
                     "subjectuuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9",
                     "roleid": {
                       "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
-                      "roles": [
-                        "SOME_STRING", "SOME_STRING"
-                      ]
+                      "role": "SOME_STRING"
                     },
                     "credtype": 1,
                     "publicdata": {
@@ -135,9 +131,7 @@ traits:
                 "subjectuuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9",
                 "roleid": {
                   "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
-                  "roles": [
-                    "SOME_STRING", "SOME_STRING"
-                  ]
+                  "role": "SOME_STRING"
                 },
                 "credtype": 32,
                 "publicdata": {
@@ -163,9 +157,7 @@ traits:
                 "subjectuuid": "e61c3e6b-9c54-4b81-8ce5-f9039c1d04d9",
                 "roleid": {
                   "authority": "484b8a51-cb23-46c0-a5f1-b4aebef50ebe",
-                  "roles": [
-                    "SOME_STRING", "SOME_STRING"
-                  ]
+                  "role": "SOME_STRING"
                 },
                 "credtype": 1,
                 "publicdata": {

--- a/schemas/oic.sec.roletype.json
+++ b/schemas/oic.sec.roletype.json
@@ -11,15 +11,12 @@
           "type": "string",
           "description": "The Authority component of the entity being identified. A NULL <Authority> refers to the local entity or device."
         },
-        "roles": {
-          "type": "array",
-          "description": "Each value specifies some well known role",
-          "items": {
-            "type": "string"
-          }
+        "role": {
+          "type": "string",
+          "description": "The ID of the role being identified.",
         }
       },
-      "required": ["authority","roles"]
+      "required": ["role"]
     }
   }
 }


### PR DESCRIPTION
oic.sec.roletype does not agree with the security WG spec; change
"roles" array to be a "role" single string as described, and only
mark "role" as a required field.