### PR TITLE
Replace the placeholder URI path declarations with well-known paths

### DIFF
--- a/oic.r.acl.raml
+++ b/oic.r.acl.raml
@@ -10,7 +10,7 @@ traits:
         if:
           enum: ["oic.if.baseline"]
 
-/SecAclResURI:
+/oic/sec/acl:
   description: |
     This resource specifies the local access control list.
 

--- a/oic.r.acl2.raml
+++ b/oic.r.acl2.raml
@@ -10,7 +10,7 @@ traits:
         if:
           enum: ["oic.if.baseline"]
 
-/SecAclResURI:
+/oic/sec/acl2:
   description: |
     This resource specifies the local access control list.
 

--- a/oic.r.amacl.raml
+++ b/oic.r.amacl.raml
@@ -10,7 +10,7 @@ traits:
         if:
             enum: ["oic.if.baseline"]
 
-/SecAmaclResURI:
+/oic/sec/amacl:
   description: |
     This resource specifies the host resources with access permission that is managed by an AMS.
 

--- a/oic.r.cred.raml
+++ b/oic.r.cred.raml
@@ -10,7 +10,7 @@ traits:
         if:
           enum: ["oic.if.baseline"]
 
-/SecCredResURI:
+/oic/sec/cred:
   description: |
     This resource specifies credentials a device may use to establish secure communication.
   displayName: Credential Resource

--- a/oic.r.crl.raml
+++ b/oic.r.crl.raml
@@ -10,7 +10,7 @@ traits:
         if:
             enum: ["oic.if.baseline"]
 
-/SecCrlResURI:
+/oic/sec/crl:
   description: |
     This resource specifies certificate revocation lists as X.509 objects.
 

--- a/oic.r.doxm.raml
+++ b/oic.r.doxm.raml
@@ -10,7 +10,7 @@ traits:
         if:
             enum: ["oic.if.baseline"]
 
-/SecDoxmResURI:
+/oic/sec/doxm:
   description: |
     This resource specifies properties needed to establish a device owner.
 

--- a/oic.r.pstat.raml
+++ b/oic.r.pstat.raml
@@ -10,7 +10,7 @@ traits:
         if:
             enum: ["oic.if.baseline"]
 
-/SecPstatResURI:
+/oic/sec/pstat:
   description: |
     This resource specifies device provisioning status.
 

--- a/oic.r.sacl.raml
+++ b/oic.r.sacl.raml
@@ -10,7 +10,7 @@ traits:
         if:
             enum: ["oic.if.baseline"]
 
-/SecSaclResURI:
+/oic/sec/sacl:
   description: |
     This resource specifies a signed ACL object.
 

--- a/oic.r.svc.raml
+++ b/oic.r.svc.raml
@@ -10,7 +10,7 @@ traits:
         if:
             enum: ["oic.if.baseline"]
 
-/SecSvcResURI:
+/oic/sec/svc:
   description: |
     This resource specifies the services this device recognizes.
 


### PR DESCRIPTION
OCF 1.0 Security uses well-known URIs for its resources. This change replaces the long-existing placeholder URIs in the RAML files with the well-known URI paths.
