### PR TITLE
Renamed the top-level ACL2 list to "aclist2" as discussed/requested by NathanH-S

### DIFF
--- a/oic.r.acl2.raml
+++ b/oic.r.acl2.raml
@@ -42,7 +42,7 @@ traits:
             schema: Acl2
             example: |
               {
-                "aclist": [
+                "aclist2": [
                   {
                     "aceid": 1,
                     "subject": {
@@ -140,7 +140,7 @@ traits:
         schema: Acl2
         example: |
           {
-            "aclist": [
+            "aclist2": [
               {
                 "aceid": 1,
                 "subject": {

--- a/schemas/oic.r.acl2.json
+++ b/schemas/oic.r.acl2.json
@@ -6,7 +6,7 @@
     "oic.r.acl2": {
       "type": "object",
       "properties": {
-        "aces": {
+        "aclist2": {
           "type": "array",
           "description": "Access Control Entries in the ACL resource",
           "items": {
@@ -25,5 +25,5 @@
     { "$ref": "../../core/schemas/oic.core-schema.json#/definitions/oic.core" },
     { "$ref": "#/definitions/oic.r.acl2" }
   ],
-  "required": [ "aclist", "rowneruuid" ]
+  "required": [ "aclist2", "rowneruuid" ]
 }


### PR DESCRIPTION
There will be a corresponding spec change for the rename.

This merging of the PR can be coordinated with the spec change.