### PR TITLE
Bug1811: Add length to the csr string

### DIFF
--- a/schemas/oic.r.csr.json
+++ b/schemas/oic.r.csr.json
@@ -8,6 +8,7 @@
       "properties": {
         "csr":  {
           "type": "string",
+          "maxLength": 3072,
           "description": "Signed CSR in ASN.1 in the encoding specified by the encoding property"
         },
         "encoding": {


### PR DESCRIPTION
As length field to indicate the length of the csr, as default is only 64 bytes.