### PR TITLE
[Bug1766] oic.sec.bss removal

### DIFF
--- a/schemas/oic.sec.dpmtype.json
+++ b/schemas/oic.sec.dpmtype.json
@@ -13,7 +13,7 @@
           "description": "The value can be either 8 or 16 character in length. If its only 8 characters it represents the lower byte value",
           "detail-desc": [  "1 - Manufacturer reset state",
                             "2 - Device pairing and owner transfer state",
-                            "4 - Provisiong of bootstrap services",
+                            "4 - Unused",
                             "8 - Provisioning of credential management services",
                             "16 - Provisioning of access management services",
                             "32 - Provisioning of local ACLs",


### PR DESCRIPTION
oic.sec.bss was removed from the security specification. Removing bss from the spec.

Signed-off-by: Habib Virji <habib.virji@samsung.com>