### PR TITLE
Add missing readOnly in the schema files

### DIFF
--- a/schemas/oic.r.csr.json
+++ b/schemas/oic.r.csr.json
@@ -8,11 +8,13 @@
       "properties": {
         "csr":  {
           "type": "string",
+          "readOnly": true,
           "maxLength": 3072,
           "description": "Signed CSR in ASN.1 in the encoding specified by the encoding property"
         },
         "encoding": {
           "type": "string",
+          "readOnly": true,
           "enum": [ "oic.sec.encoding.pem", "oic.sec.encoding.der" ],
           "description": "A string specifying the encoding format of the data contained in csr",
           "detail-desc": [  "oic.sec.encoding.pem - Encoding for PEM encoded CSR",

--- a/schemas/oic.r.pstat.json
+++ b/schemas/oic.r.pstat.json
@@ -19,11 +19,13 @@
         },
         "isop":  {
           "type": "boolean",
+          "readOnly": true,
           "description": "true indicates device is operational"
         },
         "cm":   {
           "allOf": [
             {
+              "readOnly": true,
               "description": "Current device provisioning mode"
             },
             {

--- a/schemas/oic.sec.dostype.json
+++ b/schemas/oic.sec.dostype.json
@@ -19,6 +19,7 @@
         },
         "p": {
           "type": "boolean",
+          "readOnly": true,
           "default": true,
           "description": "'p' is TRUE when the 's' state is pending until all necessary changes to device resources are complete."
         }

--- a/schemas/oic.sec.roletype.json
+++ b/schemas/oic.sec.roletype.json
@@ -9,10 +9,12 @@
       "properties": {
         "authority": {
           "type": "string",
+          "readOnly": true,
           "description": "The Authority component of the entity being identified. A NULL <Authority> refers to the local entity or device."
         },
         "role": {
           "type": "string",
+          "readOnly": true,
           "description": "The ID of the role being identified."
         }
       },


### PR DESCRIPTION
Few properties defined as read only but were not declared as readonly
in the schema files.

Signed-off-by: Habib Virji <habib.virji@samsung.com>