### PR TITLE
CR 2390: Escalation

### DIFF
--- a/schemas/oic.sec.cred-base.json
+++ b/schemas/oic.sec.cred-base.json
@@ -14,7 +14,8 @@
           "anyOf": [
             {
               "description": "The id of the device, which the cred entry applies to or \"*\" for wildcard identity",
-              "type": "string", "pattern": "^\\*$"
+              "type": "string",
+              "pattern": "^\\*$"
             },
             {
               "$ref": "https://openconnectivityfoundation.github.io/core/schemas/oic.types-schema.json#/definitions/uuid"


### PR DESCRIPTION
CR 2390 resolves security vulnerability for cases when certificate credentials are used to verify identity in secure connections.
To support legacy deployments and for CTT use, wildcard support should be used.
In future deployments, wildcard use is discouraged.