### PR TITLE
BZ 3426: Add deviceuuid Query Parameter to doxm Data Model

### DIFF
--- a/swagger2.0/oic.sec.doxm.swagger.json
+++ b/swagger2.0/oic.sec.doxm.swagger.json
@@ -19,7 +19,8 @@
         "description": "This Resource specifies properties needed to establish a Device owner.\n",
         "parameters": [
           {"$ref": "#/parameters/interface"},
-          {"$ref": "#/parameters/owned"}
+          {"$ref": "#/parameters/owned"},
+          {"$ref": "#/parameters/deviceuuid"}
         ],
         "responses": {
             "200": {
@@ -82,6 +83,12 @@
       "in": "query",
       "name": "owned",
       "type": "boolean"
+    },
+    "deviceuuid": {
+      "in": "query",
+      "name": "deviceuuid",
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     }
   },
   "definitions": {


### PR DESCRIPTION
This PR addresses Bugzilla 3426 and defines the `deviceuuid` query parameter for GET requests of the `doxm` Resource.